### PR TITLE
[VRFPP-36] Fix an issue where selecting a new component while placing a component breaks component placement

### DIFF
--- a/Assets/Scripts/ComponentPlacementManager.cs
+++ b/Assets/Scripts/ComponentPlacementManager.cs
@@ -59,6 +59,10 @@ namespace WorkstationDesigner
 		{
 			this.ActiveComponent = component;
 
+			if (this.PlacementComponent != null)
+			{
+				Destroy(this.PlacementComponent);
+			}
 			this.PlacementComponent = GameObject.CreatePrimitive(PrimitiveType.Cube);
 			this.PlacementComponent.layer = 2; // Ignore raycast
 			this.PlacementComponent.AddComponent<PlacementComponent>();


### PR DESCRIPTION
Currently, selecting a new component while placing a component breaks component placement. This PR fixes that by deleting any previously existing PlacementComponent when a new component is made active.