### PR TITLE
[VRFPP-38] Fix components flashing in the center of the floor when selected

### DIFF
--- a/Assets/Scripts/ComponentPlacementManager.cs
+++ b/Assets/Scripts/ComponentPlacementManager.cs
@@ -64,6 +64,7 @@ namespace WorkstationDesigner
 				Destroy(this.PlacementComponent);
 			}
 			this.PlacementComponent = GameObject.CreatePrimitive(PrimitiveType.Cube);
+			this.PlacementComponent.GetComponent<Renderer>().enabled = false;
 			this.PlacementComponent.layer = 2; // Ignore raycast
 			this.PlacementComponent.AddComponent<PlacementComponent>();
 			this.PlacementComponent.transform.localScale = new Vector3(component.FootprintDimensions.Item1, 6, component.FootprintDimensions.Item2);

--- a/Assets/Scripts/ComponentPlacementManager.cs
+++ b/Assets/Scripts/ComponentPlacementManager.cs
@@ -59,6 +59,10 @@ namespace WorkstationDesigner
 		{
 			this.ActiveComponent = component;
 
+			if (this.PlacementComponent != null)
+			{
+				Destroy(this.PlacementComponent);
+			}
 			this.PlacementComponent = GameObject.CreatePrimitive(PrimitiveType.Cube);
 			this.PlacementComponent.layer = 2; // Ignore raycast
 			this.PlacementComponent.AddComponent<PlacementComponent>();


### PR DESCRIPTION
Based off of #16.
Currently, when a placement component is selected, it briefly flashes in the center of the floor. This PR fixes this by having those components start off disabled.